### PR TITLE
Updating the callbacks to arrow functions

### DIFF
--- a/rzp-ionic3-example/src/pages/home/home.ts
+++ b/rzp-ionic3-example/src/pages/home/home.ts
@@ -28,12 +28,17 @@ export class HomePage {
       }
     };
 
-    var successCallback = function(payment_id) {
+    var successCallback = (payment_id) => {
       alert('payment_id: ' + payment_id);
+      //Navigate to another page using the nav controller
+      //this.navCtrl.setRoot(SuccessPage)
+      //Inject the necessary controller to the constructor
     };
 
-    var cancelCallback = function(error) {
+    var cancelCallback = (error) => {
       alert(error.description + ' (Error ' + error.code + ')');
+      //Navigate to another page using the nav controller
+      //this.navCtrl.setRoot(ErrorPage)
     };
 
     RazorpayCheckout.open(options, successCallback, cancelCallback);


### PR DESCRIPTION
The component instance is not available in the success and failure callbacks. Regular functions overwrites this with the reference to the function itself. Hence success callbacks need to arrow functions. 
'this' keyword inside the arrow functions would be the page component itself.